### PR TITLE
Add synchronization at room init

### DIFF
--- a/js/src/components/Canvas.jsx
+++ b/js/src/components/Canvas.jsx
@@ -50,6 +50,14 @@ class Canvas extends React.Component {
     this.ctx.closePath();
   }
 
+  drawLines(lines) {
+    for (var i = 0; i < lines.length; i++) {
+      let line = lines[i];
+      this.drawLine(line.prevX, line.prevY, line.currX, line.currY);
+      console.log(line);
+    }
+  }
+
   findxy(res, e) {
     if (res == 'down') {
       this.prevX = this.currX;
@@ -98,7 +106,7 @@ class Canvas extends React.Component {
 }
 
 Canvas.propTypes = {
-    sendDrawMessage: React.PropTypes.func,
+  sendDrawMessage: React.PropTypes.func,
 };
 
 module.exports = Canvas;

--- a/js/src/components/VideoPlayer.jsx
+++ b/js/src/components/VideoPlayer.jsx
@@ -20,6 +20,7 @@ class VideoPlayer extends React.Component {
 
     this.canvas.addEventListener('click', () => {
       this.playPause();
+      this.props.sendVideoSyncMessage(this.getState());
     });
 
     this.video.addEventListener('timeupdate', () => {
@@ -115,6 +116,10 @@ class VideoPlayer extends React.Component {
       </div>
     );
   }
+}
+
+VideoPlayer.propTypes = {
+  sendVideoSyncMessage: React.PropTypes.func,
 }
 
 module.exports = VideoPlayer;


### PR DESCRIPTION
Room now tracks video + canvas state and sends it when someone first joins

Also restructured react flow a little: passing a "send message" function down to the component rather than using events. This way it's easier to control when a message is actually sent.
